### PR TITLE
fixed two bugs where the player could swap two invalid baits

### DIFF
--- a/TackleTabby/Assets/Prefabs/FieldBlock.prefab
+++ b/TackleTabby/Assets/Prefabs/FieldBlock.prefab
@@ -182,7 +182,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   BaitReference: {fileID: 11400000, guid: e93bd98bb24c77041b6cca87e2f3b5c2, type: 2}
   SpriteRenderer: {fileID: 6795579963323379539}
-  RaycastDistance: 1
+  RaycastDistance: 0.5
 --- !u!114 &7574904681287063491
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/TackleTabby/Assets/Scripts/Blocks/FieldBlock.cs
+++ b/TackleTabby/Assets/Scripts/Blocks/FieldBlock.cs
@@ -182,16 +182,22 @@ public class FieldBlock : MonoBehaviour
     public RaycastHit2D PerformSafeCast(Vector2 origin, Vector2 direction, float distance)
     {
         Debug.DrawRay(origin, direction * RaycastDistance, Color.red, 3f);
-            
-        _collider.enabled = false;
+
+        bool wasActive = _collider.enabled;
+        if (wasActive)
+            _collider.enabled = false;
+        
         RaycastHit2D hit = Physics2D.Raycast(origin, direction, distance);
-        _collider.enabled = true;
+        
+        if (wasActive)
+            _collider.enabled = true;
+        
         return hit;
     }
 
     public FieldBlock FindNeighbourInDirection(Vector2 direction)
     {
-        RaycastHit2D cast = PerformSafeCast(transform.position, direction, Mathf.Infinity);
+        RaycastHit2D cast = PerformSafeCast(transform.position, direction, RaycastDistance);
         if (!cast)
             return null;
 


### PR DESCRIPTION
## bugs
Bug 1: [Trello](https://trello.com/c/014l9cma/94-bug-1-de-speler-kan-twee-baits-buiten-elkaars-range-swappen-na-een-match-is-gemaakt)
and Bug 2: [Trello](https://trello.com/c/Z4OpG80E/95-bug-2-de-speler-kan-een-bait-swappen-met-een-bait-boven-het-speel-veld-net-na-er-een-match-is-gemaakt-op-die-row)
## Description
This fixes two bugs, the first is where the player can swap two baits from a too far distance after a gap is created cause of a match. 
The second is a bug where the player can swap the top bait with a bait above it after it respawned cause of a match.