### PR TITLE
Bug/multiple touch end

### DIFF
--- a/TackleTabby/Assets/Scripts/Swapping/CheckPressStatus.cs
+++ b/TackleTabby/Assets/Scripts/Swapping/CheckPressStatus.cs
@@ -11,6 +11,7 @@ public class CheckPressStatus : MonoBehaviour
     public UnityEvent<Vector2, Vector2> OnSwipeEnded = new();
 
     private Vector2 _startPosition;
+    private bool _hasStarted = false;
     
     public void OnPressStart(InputAction.CallbackContext context)
     {
@@ -20,7 +21,8 @@ public class CheckPressStatus : MonoBehaviour
         TouchState touch = context.ReadValue<TouchState>();
         if (touch.phase != TouchPhase.Began)
             return;
-        
+
+        _hasStarted = true;
         _startPosition = touch.position;
     }
 
@@ -33,6 +35,10 @@ public class CheckPressStatus : MonoBehaviour
         if (touch.phase != TouchPhase.Ended)
             return;
 
+        if (!_hasStarted)
+            return;
+
+        _hasStarted = false;
         Vector2 direction = (touch.position - _startPosition);
         OnSwipeEnded.Invoke(_startPosition, direction);
     }


### PR DESCRIPTION
## Description
Fixed an issue when the player touches bait and quickly releases only to swipe directly after, bait will always be swapped back