### PR TITLE
Bug/WinScreen

### DIFF
--- a/TackleTabby/Assets/Scenes/GameScenes/MainGameScene.unity
+++ b/TackleTabby/Assets/Scenes/GameScenes/MainGameScene.unity
@@ -12417,7 +12417,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6339575637694589124, guid: def7f74b249fbcd4ca6cdfd5e75685c0, type: 3}
       propertyPath: OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OpenOverlay
+      value: ReadyWin
       objectReference: {fileID: 0}
     - target: {fileID: 6339575637694589124, guid: def7f74b249fbcd4ca6cdfd5e75685c0, type: 3}
       propertyPath: OnOpened.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
@@ -13036,7 +13036,7 @@ PrefabInstance:
       objectReference: {fileID: 1136517567}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
@@ -13051,6 +13051,10 @@ PrefabInstance:
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 110480106}
@@ -13063,6 +13067,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1805164455}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 1721996328}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
@@ -13072,6 +13080,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
@@ -13087,6 +13099,10 @@ PrefabInstance:
       value: CheckCaught
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: OpenOverlay
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: EncyclopediaOpenBtn, Assembly-CSharp
       objectReference: {fileID: 0}
@@ -13099,7 +13115,15 @@ PrefabInstance:
       value: ToggleHighlight, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
+      value: WinBehaviour, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_BoolArgument
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
@@ -13112,6 +13136,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
       propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181481499435501205, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}
+      propertyPath: OnClosed.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 8551632943396275512, guid: bc34db89e4e3fc840a555c1e87229268, type: 3}

--- a/TackleTabby/Assets/Scripts/Win/WinBehaviour.cs
+++ b/TackleTabby/Assets/Scripts/Win/WinBehaviour.cs
@@ -14,15 +14,26 @@ public class WinBehaviour : MonoBehaviour, IOverlayMenu
     public UnityEvent<IOverlayMenu> OnClosed;
 
     private bool _isOpen = false;
+    private bool _hasWinReady = false;
+    private bool _closed = false;
+
+    public void ReadyWin()
+    {
+        _hasWinReady = true;
+    }
 
     [ContextMenu("UI Tests/Open UI")]
     public void OpenOverlay()
     {
+        if (!_hasWinReady || _closed)
+            return;
+        
         if (_isOpen)
             return;
 
         StartCoroutine(OpenOverlayCoroutine());
         _isOpen = true;
+        _hasWinReady = false;
     }
 
     [ContextMenu("UI Tests/Close UI")]
@@ -30,6 +41,7 @@ public class WinBehaviour : MonoBehaviour, IOverlayMenu
     {
         WinPanelAnimator.SetTrigger("ExitWin");
         _isOpen = false;
+        _closed = true;
 
         OnClosed.Invoke(this);
 
@@ -58,9 +70,7 @@ public class WinBehaviour : MonoBehaviour, IOverlayMenu
 
     private IEnumerator OpenOverlayCoroutine()
     {
-        yield return new WaitForSeconds(0.5f);
-        while (MenuCommunicator.Instance.HasMenuOpen)
-            yield return new WaitForSeconds(0.5f);
+        yield return new WaitUntil(() => !MenuCommunicator.Instance.HasMenuOpen);
 
         WinPanel.SetActive(true);
 


### PR DESCRIPTION
## Trello
Bug 6: [Trello](https://trello.com/c/3AOqDr2S/196-bug-6-bij-het-winnen-zal-eerst-het-win-scherm-opkomen-en-bijna-direct-daarna-weggeduwd-worden-door-de-caught-pop-up)

## Description
Now only opens the win overlay after the catch-pop-up was closed